### PR TITLE
Save ENV content on activate! and restore deactivate!

### DIFF
--- a/lib/fake_env.rb
+++ b/lib/fake_env.rb
@@ -3,35 +3,14 @@ require 'fake_env/version'
 
 module FakeEnv
   class << self
-    attr_reader :actual, :fake, :actual_get_method, :actual_set_method
+    attr_reader :actual
 
     def activate!
-      @actual = ENV.clone
-      @fake = Hash.new do |fake, key|
-        val = @actual[key]
-
-        fake[key] = val ? val : val.clone
-      end
-
-      @actual_get_method ||= ENV.method(:[])
-      @actual_set_method ||= ENV.method(:[]=)
-
-      class << ENV
-        def [](key)
-          FakeEnv.fake[key]
-        end
-
-        def []=(key, val)
-          FakeEnv.fake[key] = val.freeze
-        end
-      end
+      @actual = ENV.to_h
     end
 
     def deactivate!
-      class << ENV
-        define_method(:[], FakeEnv.actual_get_method)
-        define_method(:[]=, FakeEnv.actual_set_method)
-      end
+      ENV.replace(@actual)
     end
 
     def within


### PR DESCRIPTION
This solves #2.

Note that it makes child processes take over a faked ENV.

``` ruby
require 'fake_env'

ENV["foo"] = "0"
FakeEnv.within do
  ENV["foo"] = "1"
  puts `echo $foo` # before: 0 / after: 1
end
```
